### PR TITLE
Fix the hierarchical view of the categories dropdown

### DIFF
--- a/order-bender.php
+++ b/order-bender.php
@@ -89,7 +89,7 @@ class mtekk_order_bender
 			'id' => $this->unique_prefix . '_' . $taxonomy->name . '_primary_term',
 			'class' => $this->unique_prefix . '_primary_term',
 			'echo' => 1,
-			'depth' => -1,
+			'depth' => 0,
 			'hierarchical' => 1,
 			'show_option_none' => __( '&mdash; Select &mdash;' ),
 			'option_none_value' => '0',


### PR DESCRIPTION
Change the depth attribute of wp_dropdown_categories from -1 to 0 to fix the hierarchical view of the categories dropdown (-1 is an incorrect value).